### PR TITLE
feature: swagger documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,12 @@ group :development, :test do
   gem "combustion", github: "abak-press/combustion"
 end
 
-gem 'mime-types', '< 3.0' if RUBY_VERSION < '2'
-gem 'rack', '< 2.0' if RUBY_VERSION < '2.2.2'
-gem 'migration_comments', '= 0.3.2' if RUBY_VERSION < '2'
+if RUBY_VERSION < '2'
+  gem 'mime-types', '< 3.0'
+  gem 'migration_comments', '= 0.3.2'
+  gem 'json', '< 2.0.0'
+  gem 'rack', '< 2.0.0'
+end
 
 # Specify your gem's dependencies in apress-api.gemspec
 gemspec

--- a/app/docs/swagger/v1/controllers/apress/api/tokens_controller.rb
+++ b/app/docs/swagger/v1/controllers/apress/api/tokens_controller.rb
@@ -1,0 +1,64 @@
+module Swagger
+  module V1
+    module Controllers
+      module Apress
+        module Api
+          class TokensController < ::Apress::Api::Swagger::Schema
+            swagger_path '/clients/{access_id}/tokens' do
+              operation :post do
+                key :produces, ['application/json']
+
+                key :description, 'Refreshes token for client with given access_id'
+                key :operationId, 'refreshToken'
+                key :tags, ['clients']
+
+                parameter do
+                  key :name, :access_id
+                  key :in, :path
+                  key :description, "client's access_id"
+                  key :required, true
+                  key :type, :string
+                end
+
+                parameter do
+                  key :name, 'refresh_token'
+                  key :in, :body
+                  key :description, "Client's refresh token"
+                  key :required, true
+                  schema type: :object do
+                    property :refresh_token do
+                      key :type, :string
+                    end
+                  end
+                end
+
+                response 200 do
+                  key :description, 'Success response'
+                  schema type: 'object' do
+                    property :client do
+                      key :'$ref', :'Swagger::V1::Models::Apress::Api::Client'
+                    end
+                  end
+                end
+
+                response 400 do
+                  key :description, 'refresh token not valid for current access_id'
+                  schema do
+                    key :'$ref', :'Swagger::V1::Models::Apress::Api::SimpleError'
+                  end
+                end
+
+                response 403 do
+                  key :description, 'refresh token is expired'
+                  schema do
+                    key :'$ref', :'Swagger::V1::Models::Apress::Api::SimpleError'
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/docs/swagger/v1/models/apress/api/client.rb
+++ b/app/docs/swagger/v1/models/apress/api/client.rb
@@ -1,0 +1,53 @@
+module Swagger
+  module V1
+    module Models
+      module Apress
+        module Api
+          class Client < ::Apress::Api::Swagger::Schema
+            swagger_schema name.to_sym do
+              key :required, [
+                :id,
+                :access_id,
+                :secret_token_expire_at,
+                :secret_token,
+                :refresh_token_expire_at,
+                :refresh_token,
+                :user_agent,
+                :updated_at,
+                :created_at
+              ]
+
+              property :id do
+                key :type, :integer
+                key :format, :int64
+              end
+
+              {
+                access_id: '6760dc04-db3e-4c18-b7a3-5cd68718e869',
+                secret_token: 'fflnVd5JyQAlH4EICLEV/c49RQRj0MaINNKFAVsuxngfcQHzLw7L9uF7fnOm/mbn4SBs3ssCUjvjcTjb4nQ==',
+                refresh_token: 'kmwCUAQxg2YOCZg2ENLQ4t4hfH8DYKPb6e+6ZkSl1K/zOyAXflUeL9Ef/jL7rEMTfuu0QqbrMm8SNsEnww==',
+                secret_token_expire_at: Time.current,
+                refresh_token_expire_at: Time.current,
+                user_agent: nil
+              }.each do |k, v|
+                property k do
+                  key :type, :string
+                  key :example, v if v
+                end
+              end
+
+              [:created_at, :updated_at].each do |k|
+                property k do
+                  key :type, :string
+                  key :format, :date
+                end
+              end
+            end
+
+            ActiveSupport.run_load_hooks(:'swagger/models/v1/apress/api/client', self)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/docs/swagger/v1/models/apress/api/simple_error.rb
+++ b/app/docs/swagger/v1/models/apress/api/simple_error.rb
@@ -1,0 +1,27 @@
+module Swagger
+  module V1
+    module Models
+      module Apress
+        module Api
+          class SimpleError < ::Apress::Api::Swagger::Schema
+            swagger_schema name.to_sym do
+              keys = [
+                :status,
+                :message,
+                :backtrace
+              ]
+
+              key :required, keys
+
+              keys.each do |k|
+                property k do
+                  key :type, :string
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/docs/swagger/v1/models/apress/api/unproccesable_error.rb
+++ b/app/docs/swagger/v1/models/apress/api/unproccesable_error.rb
@@ -1,0 +1,25 @@
+module Swagger
+  module V1
+    module Models
+      module Apress
+        module Api
+          class UnproccesableError < ::Apress::Api::Swagger::Schema
+            swagger_schema name.to_sym do
+              key :required, :errors
+
+              property :errors do
+                key :type, :array
+                items do
+                  key :type, :object
+                  property :error do
+                    key :type, :object
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/docs/swagger/v1/root.rb
+++ b/app/docs/swagger/v1/root.rb
@@ -1,0 +1,29 @@
+module Swagger
+  module V1
+    class Root < ::Apress::Api::Swagger::Schema
+      swagger_root do
+        key :swagger, '2.0'
+        info do
+          key :version, '1.0.0'
+          key :title, 'Apress API'
+          key :description, 'Apress API'
+          key :termsOfService, 'None'
+          contact do
+            key :name, 'Aback-Press Team'
+          end
+        end
+
+        key :host, defined?(HOST) ? HOST : '/'
+        key :basePath, '/api/v1'
+        key :produces, ['application/json']
+
+        security_definition :authorization do
+          key :type, :apikey
+          key :name, :apiKey
+          key :description, 'signature for response'
+          key :in, :header
+        end
+      end
+    end
+  end
+end

--- a/apress-api.gemspec
+++ b/apress-api.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jbuilder", ">= 2.3.1"
   spec.add_runtime_dependency "attr_extras", ">= 4.4.0"
   spec.add_runtime_dependency "migration_comments", ">= 0.3.2"
+  spec.add_runtime_dependency 'swagger-blocks', '>= 1.3'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/apress/api.rb
+++ b/lib/apress/api.rb
@@ -5,5 +5,6 @@ require "multi_json"
 require "jbuilder"
 require "api_auth"
 require "attr_extras"
+require 'swagger/blocks'
 require "apress/api/version"
 require "apress/api/engine"

--- a/lib/apress/api/engine.rb
+++ b/lib/apress/api/engine.rb
@@ -2,13 +2,20 @@ module Apress
   module Api
     class Engine < Rails::Engine
       config.autoload_paths << config.root.join("lib")
+      config.paths.add 'app/docs', :eager_load => true
 
       initializer "apress-api", before: :load_init_rb do |app|
         app.config.paths["db/migrate"].concat(config.paths["db/migrate"].expanded)
 
+        glob = config.root.join('app/docs/**/*.rb')
+        app.config.to_prepare do
+          Dir[glob].each { |file| require_dependency file }
+        end
+
         app.config.api = {
           secret_token_ttl: 1.hour,
-          refresh_token_ttl: 1.week
+          refresh_token_ttl: 1.week,
+          v1_doc_path: 'docs/swagger/v1.json'
         }
 
         ::MultiJson.use :oj

--- a/lib/apress/api/swagger/generator.rb
+++ b/lib/apress/api/swagger/generator.rb
@@ -1,0 +1,25 @@
+module Apress
+  module Api
+    module Swagger
+      class Generator
+        def initialize(path = nil)
+          @path = path
+        end
+
+        def data
+          return @data if defined?(@data)
+          classes = Apress::Api::Swagger::Schema.swagger_classes
+          @data = ::Swagger::Blocks.build_root_json(classes)
+        end
+
+        def generate_file
+          if @path
+            File.open(@path, 'w') { |file| file.write(data.to_json) }
+          else
+            raise 'No Docs path provided'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/apress/api/swagger/schema.rb
+++ b/lib/apress/api/swagger/schema.rb
@@ -1,0 +1,17 @@
+module Apress
+  module Api
+    module Swagger
+      class Schema
+        include ::Swagger::Blocks
+
+        def self.schema_name(name)
+          "#{self.name}::#{name.to_s.camelize}".to_sym
+        end
+
+        def self.swagger_classes
+          ObjectSpace.each_object(Class).select { |klass| klass < self }
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -1,0 +1,12 @@
+namespace :docs do
+  desc 'Generate api documentation'
+  task generate: :environment do
+    filename = 'swagger_v1.json'
+    path = Rails.application.config.api[:v1_doc_path]
+    FileUtils.mkdir_p(File.dirname(path))
+
+    Apress::Api::Swagger::Generator.new(path).generate_file
+
+    puts 'Done.'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require "simplecov"
 SimpleCov.start "rails" do
   minimum_coverage 95
   add_filter "/lib/apress/api/testing/"
+  add_filter "/lib/apress/api/swagger/"
+  add_filter "/app/docs"
 end
 
 require "pry-debugger"


### PR DESCRIPTION
WIP
- [x] основной скелет
- [x] нормальные описания + косяки копипаста и исправить ошибки (помощь приветствуется)

Общая идея, как будет использоваться в проетах
1. Используем гем [swagger-blocks](https://github.com/fotinakis/swagger-blocks)
2. Для описание доки нужно реализовать описание экшена в контроллере + схему (`app/schemas`)
3. Схемы можно инклюдить, как в контроллеры, так и в другие схемы, те они полностью переиспользуемые
4. для просмотра будем использовать [swagger-engine](https://github.com/batdevis/swagger_engine), выглядит это примерно так - http://petstore.swagger.io/, оно у нас будет на своем endpoint, например, pulscen.ru/apidocs, сам маршрут можно определять только для staiging/dev окружения.
http://joxi.net/V2VL1dnh0ZQELr
5. доки генерятся в фаил `docs/swagger/v1.json` с помощью таски `rake docs:generate`, будем запускать при деплое, если нужно будет для продакшена можно заменить swagger-engine на [swagger-ui_rails](https://github.com/d4be4st/swagger-ui_rails), там придется делать свой контроллер вьюхи и тд, пока решил в простом варианте сделать поэтому swagger-engine.
там нужно будет придумывать свой контроллер и прочее, пока его не стал делать, тк пока не требуется.

Плюсы подхода:
- нет устаревшей документации
- удобный однотипный формат
- описание с помощью ruby кода
- все доки в одном месте
- возможно получится заюзать схемы в тестах вьюх

Минусы:
- загрузка приложения чуть пострадает, вряди ли заметно
- код документации занимает место в коде контроллера, может в некоторых случаях будет мешатся (думаю, это можно исправить, просто вынесев его в отдельный модуль)
