### PR TITLE
chore: fix migration_comments version

### DIFF
--- a/apress-api.gemspec
+++ b/apress-api.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "multi_json", ">= 1.11.2"
   spec.add_runtime_dependency "jbuilder", ">= 2.3.1"
   spec.add_runtime_dependency "attr_extras", ">= 4.4.0"
-  spec.add_runtime_dependency "migration_comments", ">= 0.3.2"
+  spec.add_runtime_dependency "migration_comments", "~> 0.3"
   spec.add_runtime_dependency 'swagger-blocks', '>= 1.3'
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
Зафиксировал migration_comments версию на 0.3, т.к. более поздние версии зависят от activerecord 4.2, что вызывает ошибку в тестах для рельсов 3.2, например
