### PR TITLE
feat(gems): update swagger-core dependency

### DIFF
--- a/apress-api.gemspec
+++ b/apress-api.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "multi_json", ">= 1.11.2"
   spec.add_runtime_dependency "jbuilder", ">= 2.3.1"
   spec.add_runtime_dependency "attr_extras", ">= 4.4.0"
-  spec.add_runtime_dependency 'swagger-core', '>= 0.2.3.1'
+  spec.add_runtime_dependency 'swagger-core', '>= 0.3.0'
   spec.add_runtime_dependency 'swagger-blocks', '>= 1.3'
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
Автор swagger-core принял мои фиксы и выпустил версию гема.
Необходимость в форке отпала.

@Napolskih https://github.com/abak-press/swagger-rb можно будет удалить потом, как и версию гема из нашего источника.