### PR TITLE
fix(new_relic): выпил ::NewRelic::Agent::Instrumentation::Rails3::Errors

### DIFF
--- a/lib/apress/api/api_controller/base.rb
+++ b/lib/apress/api/api_controller/base.rb
@@ -46,7 +46,6 @@ module Apress
 
           if Rails::VERSION::MAJOR == 3
             include ::NewRelic::Agent::Instrumentation::Rails3::ActionController
-            include ::NewRelic::Agent::Instrumentation::Rails3::Errors
           end
         end
         # :nocov:


### PR DESCRIPTION
https://jira.railsc.ru/browse/PC4-19900

модуль был удален, использвание методов в коде нет:
https://jira.railsc.ru/browse/PC4-19900?focusedCommentId=146483&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-146483