### PR TITLE
fix(gemspec): add min version for addressable

### DIFF
--- a/apress-api.gemspec
+++ b/apress-api.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'swagger-core', '>= 0.3.0'
   spec.add_runtime_dependency 'interactor'
   spec.add_runtime_dependency 'pundit'
+  spec.add_runtime_dependency 'addressable', '>= 2.4.0'
 
   spec.add_runtime_dependency 'resque-integration'
   spec.add_runtime_dependency 'apress-documentation', '>= 0.2.0'

--- a/lib/apress/api/version.rb
+++ b/lib/apress/api/version.rb
@@ -1,5 +1,5 @@
 module Apress
   module Api
-    VERSION = '1.22.0'.freeze
+    VERSION = '1.22.1'.freeze
   end
 end


### PR DESCRIPTION
В реквесте https://github.com/abak-press/apress-api/pull/65 была добавлена зависимость от гема addressable
Файлик, который подтягивается тут https://github.com/abak-press/apress-api/blob/master/lib/apress/api.rb#L8 появился только в версии 2.4.0, хотя в гемах может выставиться меньшая.
Указал минимальную версию для используемого функционала.