### PR TITLE
Rails 6 support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,30 +1,58 @@
-build:
-  test:
-    image: abakpress/dind-testing
-    privileged: true
-    pull: true
-    volumes:
-      - /home/data/drone/images:/images
-      - /home/data/drone/gems:/bundle
-    environment:
-      - COMPOSE_FILE_EXT=drone
-      - RUBY_IMAGE_TAG=2.2-latest
-      - POSTGRES_IMAGE_TAG=9.3-latest
-    commands:
-      - wrapdocker docker -v
+name: build
 
-      - fetch-images --image abakpress/ruby-app:$RUBY_IMAGE_TAG
+kind: pipeline
+type: docker
 
-      - dip provision
-      - dip rspec
+volumes:
+- name: images
+  host:
+    path: /home/data/drone/images
+- name: bundle
+  host:
+    path: /home/data/drone/gems
+- name: keys
+  host:
+    path: /home/data/drone/key_cache
 
-  release:
-    image: abakpress/gem-publication
-    pull: true
-    when:
-      event: push
-      branch: master
-    volumes:
-      - /home/data/drone/rubygems:/root/.gem
-    commands:
-      - release-gem --public
+spec_step_common: &spec_step_common
+  image: abakpress/dind-testing
+  pull: always
+  privileged: true
+  volumes:
+  - name: images
+    path: /images
+  - name: bundle
+    path: /bundle
+  - name: keys
+    path: /ssh_keys
+  commands:
+  - prepare-build
+
+  - fetch-images
+    --image whilp/ssh-agent
+    --image abakpress/ruby-app:$RUBY_IMAGE_TAG
+
+  - dip ssh add -T -v /ssh_keys -k /ssh_keys/id_rsa
+  - dip provision
+  - dip rspec
+
+steps:
+- name: Tests Ruby 2.5
+  environment:
+    COMPOSE_FILE_EXT: drone
+    DOCKER_RUBY_VERSION: 2.5
+    RUBY_IMAGE_TAG: 2.5-latest
+    RAILS_ENV: test
+    BUNDLER_OPTIONS: " --without 'development production profile console assets' -j 10 --quiet"
+    BUNDLER_VERSION: 1.17.3
+  <<: *spec_step_common
+
+- name: release
+  image: abakpress/gem-publication:latest
+  pull: true
+  when:
+    event: push
+    branch: master
+    status: success
+  commands:
+  - release-gem --public

--- a/Appraisals
+++ b/Appraisals
@@ -1,16 +1,3 @@
-appraise "rails3.2" do
-  gem "rails", "~> 3.2.0", require: false
-  gem "strong_parameters", ">= 0.2", require: false
-end
-
-appraise "rails4.0" do
-  gem "rails", "~> 4.0.0", require: false
-end
-
-appraise "rails4.1" do
-  gem "rails", "~> 4.1.0", require: false
-end
-
 appraise "rails4.2" do
   gem "rails", "~> 4.2.0", require: false
 end
@@ -28,4 +15,10 @@ end
 appraise "rails5.2" do
   gem "rails", "~> 5.2.0", require: false
   gem "rails-controller-testing", require: false
+end
+
+appraise "rails6.0" do
+  gem "rails", "~> 6.0.0", require: false
+  gem "rails-controller-testing", require: false
+  gem 'rspec-rails', '4.0.0.beta3'
 end

--- a/apress-api.gemspec
+++ b/apress-api.gemspec
@@ -14,9 +14,11 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rails", ">= 3.1.0", "< 6.0.0"
+  spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 2.5'
+
+  spec.add_runtime_dependency "rails", ">= 4.2", "< 6.1.0"
   spec.add_runtime_dependency 'pg'
   spec.add_runtime_dependency "api-auth", ">= 1.3.1"
   spec.add_runtime_dependency "oj", ">= 2.9.9"

--- a/dip.yml
+++ b/dip.yml
@@ -1,8 +1,8 @@
 version: '1'
 
 environment:
-  DOCKER_RUBY_VERSION: 2.2
-  RUBY_IMAGE_TAG: 2.2-latest
+  DOCKER_RUBY_VERSION: 2.5
+  RUBY_IMAGE_TAG: 2.5-latest
   POSTGRES_IMAGE_TAG: 9.6-0.7.0
   COMPOSE_FILE_EXT: development
   RAILS_ENV: test

--- a/spec/controllers/v1/callbacks_controller_spec.rb
+++ b/spec/controllers/v1/callbacks_controller_spec.rb
@@ -18,7 +18,7 @@ describe Apress::Api::V1::CallbacksController, type: :controller do
   describe "#create" do
     context "when client present and allowed" do
       before do
-        client.update_attributes(access_id: 'service_access_id')
+        client.update(access_id: 'service_access_id')
       end
 
       context 'when params are valid' do

--- a/spec/helpers/paginating_cache_spec.rb
+++ b/spec/helpers/paginating_cache_spec.rb
@@ -1,30 +1,13 @@
 require 'spec_helper'
-SIMPLE_TEST = <<-JBUILDER
-  json.paginating_cache! @collection, nil, skip_digest: true do
-    json.title 'test'
-  end
-JBUILDER
-
-TEST_WITH_CACHING = <<-JBUILDER
-  json.paginating_cache! @collection, ['v1', @collection], expire_in: 30.minutes, skip_digest: true do
-    json.title 'test'
-  end
-JBUILDER
 
 def jbuild(source_key, collection)
-  partials = {
-    'test.json.jbuilder' => SIMPLE_TEST,
-    'test_with_cache_key.json.jbuilder' => TEST_WITH_CACHING
-  }
-
-  resolver = ActionView::FixtureResolver.new(partials)
-  lookup_context.view_paths = [resolver]
   assign(:collection, collection)
   MultiJson.load(render(template: source_key))
 end
 
 def view_prefix
-  if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2
+  if (Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR == 2) ||
+    (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR == 0)
     'jbuilder/views'
   else
     'jbuilder'

--- a/spec/internal/app/assets/config/manifest.js
+++ b/spec/internal/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/spec/internal/app/views/test.json.jbuilder
+++ b/spec/internal/app/views/test.json.jbuilder
@@ -1,0 +1,3 @@
+json.paginating_cache! @collection, nil, skip_digest: true do
+  json.title 'test'
+end

--- a/spec/internal/app/views/test_with_cache_key.json.jbuilder
+++ b/spec/internal/app/views/test_with_cache_key.json.jbuilder
@@ -1,0 +1,3 @@
+json.paginating_cache! @collection, ['v1', @collection], expire_in: 30.minutes, skip_digest: true do
+  json.title 'test'
+end

--- a/spec/lib/apress/api/callbacks/integration_spec.rb
+++ b/spec/lib/apress/api/callbacks/integration_spec.rb
@@ -17,7 +17,7 @@ describe Apress::Api::Callbacks::Integration, type: :mixin do
         expect(Apress::Api::DelayedFireCallback).to \
           receive(:call!).with(event: 'dynamic_params_event', params: {name: 'test_2 stuff'})
 
-        model.update_attributes(name: 'test_2')
+        model.update(name: 'test_2')
       end
     end
   end


### PR DESCRIPTION
Всем приветы в этом чате 😸 

Понадобилась поддержка Rails 6.
Rails 6 нужен Ruby 2.5. С Ruby 2.5 не совместимые рельсы ниже 4.2 - пришлось убрать. 

lookup_context.view_paths [теперь ридонли](https://github.com/rails/rails/pull/35074). 

Поправлена пара не совместимостей и деприкейшенов.